### PR TITLE
feat: implement JWT authentication for WordPress headless login

### DIFF
--- a/server/api/auth/login.post.ts
+++ b/server/api/auth/login.post.ts
@@ -1,202 +1,158 @@
-interface TestResult {
-  test: string
-  status: 'success' | 'failed'
-  data?: any
-  error?: {
-    message: string
-    status?: number
-    statusCode?: number
-    cause?: any
-  }
-}
+import type { WordPressUser, User, AuthResponse } from '~/types/auth'
 
-interface TestResults {
-  endpoint: string
-  tests: TestResult[]
-}
-
-export default defineEventHandler(async (event): Promise<TestResults> => {
+export default defineEventHandler(async (event): Promise<AuthResponse> => {
+  const { username, password } = await readBody(event)
   const config = useRuntimeConfig()
-  const wpEndpoint = config.public.wpRestEndpoint || 'https://stellarpossible.com/wp-json'
   
-  const testResults: TestResults = {
-    endpoint: wpEndpoint,
-    tests: []
-  }
-  
-  // Test 1: Basic WordPress API connectivity
-  try {
-    const response = await $fetch(`${wpEndpoint}/`, {
-      timeout: 10000
-    })
-    
-    testResults.tests.push({
-      test: 'WordPress API Basic Connectivity',
-      status: 'success',
-      data: {
-        name: response.name || 'WordPress Site',
-        description: response.description || 'No description',
-        routes: response.routes ? Object.keys(response.routes).length : 0
-      }
-    })
-  } catch (error: any) {
-    testResults.tests.push({
-      test: 'WordPress API Basic Connectivity',
-      status: 'failed',
-      error: {
-        message: error.message,
-        status: error.status || error.statusCode,
-        cause: error.cause?.code || error.code
-      }
-    })
-  }
-  
-  // Test 2: Detailed password analysis
-  if (config.wpAppPassword) {
-    const password = config.wpAppPassword
-    const passwordChars = password.split('').map((char, index) => ({
-      index,
-      char: char === ' ' ? 'SPACE' : char,
-      charCode: char.charCodeAt(0)
-    }))
-    
-    testResults.tests.push({
-      test: 'Password Analysis',
-      status: 'success',
-      data: {
-        originalLength: password.length,
-        withoutSpacesLength: password.replace(/\s/g, '').length,
-        hasSpaces: password.includes(' '),
-        startsWithSpace: password.startsWith(' '),
-        endsWithSpace: password.endsWith(' '),
-        spaceCount: (password.match(/\s/g) || []).length,
-        firstFiveChars: passwordChars.slice(0, 5),
-        lastFiveChars: passwordChars.slice(-5)
-      }
-    })
-  }
-  
-  // Test 3: Try multiple password formats
-  if (config.public.wpUser && config.wpAppPassword) {
-    const passwordVariations = [
-      { name: 'original', value: config.wpAppPassword },
-      { name: 'trimmed', value: config.wpAppPassword.trim() },
-      { name: 'no-spaces', value: config.wpAppPassword.replace(/\s/g, '') },
-      { name: 'single-spaces', value: config.wpAppPassword.replace(/\s+/g, ' ') }
-    ]
-    
-    for (const variation of passwordVariations) {
-      try {
-        const authString = Buffer.from(`${config.public.wpUser}:${variation.value}`).toString('base64')
-        
-        const response = await $fetch(`${wpEndpoint}/wp/v2/users/me`, {
-          headers: {
-            'Authorization': `Basic ${authString}`,
-            'Content-Type': 'application/json'
-          },
-          timeout: 8000
-        })
-        
-        testResults.tests.push({
-          test: `Auth Success (${variation.name})`,
-          status: 'success',
-          data: {
-            user: response.username,
-            email: response.email,
-            roles: response.roles,
-            passwordVariation: variation.name,
-            passwordLength: variation.value.length
-          }
-        })
-        
-        // If one works, we can stop testing
-        break
-        
-      } catch (error: any) {
-        testResults.tests.push({
-          test: `Auth Test (${variation.name})`,
-          status: 'failed',
-          error: {
-            message: error.message,
-            status: error.status || error.statusCode,
-            passwordVariation: variation.name,
-            passwordLength: variation.value.length
-          }
-        })
-      }
+  // Input validation
+  if (!username || !password) {
+    return {
+      success: false,
+      message: 'Username and password are required'
     }
   }
   
-  // Test 4: Manual credential test (hardcoded for debugging)
   try {
-    // Test with a known good format - replace with your actual credentials
-    const testAuthString = Buffer.from('mlvalentonis:UBQmj2mBAAGYcTlRX6zoySns').toString('base64')
+    // Authenticate with WordPress JWT
+    const wpEndpoint = config.public.wpRestEndpoint || 'https://stellarpossible.com/wp-json'
     
-    const response = await $fetch(`${wpEndpoint}/wp/v2/users/me`, {
+    // Step 1: Get JWT token using username/password
+    const jwtResponse = await $fetch(`${wpEndpoint}/jwt-auth/v1/token`, {
+      method: 'POST',
       headers: {
-        'Authorization': `Basic ${testAuthString}`,
         'Content-Type': 'application/json'
       },
-      timeout: 8000
+      body: JSON.stringify({
+        username: username,
+        password: password
+      })
     })
     
-    testResults.tests.push({
-      test: 'Manual Credential Test',
-      status: 'success',
-      data: {
-        user: response.username,
-        email: response.email,
-        roles: response.roles,
-        note: 'Hardcoded credentials work'
+    if (jwtResponse.token) {
+      // Step 2: Use JWT token to get user info
+      const response = await $fetch<WordPressUser>(`${wpEndpoint}/wp/v2/users/me`, {
+        headers: {
+          'Authorization': `Bearer ${jwtResponse.token}`,
+          'Content-Type': 'application/json'
+        }
+      })
+      
+      if (response && response.id) {
+        const user: User = {
+          id: response.id,
+          username: response.username,
+          email: response.email,
+          name: response.name,
+          roles: response.roles,
+          avatar: response.avatar_urls?.['96'] ?? null,
+          description: response.description ?? null,
+          url: response.url ?? null
+        }
+        
+        // Choose token method based on configuration
+        const useJWT = config.public.useJWT === 'true'
+        let sessionToken: string
+        
+        if (useJWT && config.jwtSecret) {
+          // Dynamic import for JWT
+          const jwt = await import('jsonwebtoken')
+          
+          // Create JWT token (recommended for production)
+          sessionToken = jwt.default.sign(
+            {
+              id: user.id,
+              username: user.username,
+              email: user.email,
+              name: user.name,
+              roles: user.roles,
+              avatar: user.avatar,
+              description: user.description,
+              iat: Math.floor(Date.now() / 1000)
+            },
+            config.jwtSecret,
+            { 
+              expiresIn: '7d',
+              issuer: 'stellarpossible-nuxt',
+              subject: user.id.toString()
+            }
+          )
+        } else {
+          // Create simple session token
+          sessionToken = Buffer.from(`${user.username}:${Date.now()}`).toString('base64')
+        }
+        
+        // Set secure HTTP-only cookie
+        setCookie(event, 'auth-token', sessionToken, {
+          httpOnly: true,
+          secure: process.env.NODE_ENV === 'production',
+          sameSite: 'strict',
+          maxAge: 60 * 60 * 24 * 7, // 7 days
+          path: '/'
+        })
+        
+        // Store user data (only if not using JWT)
+        if (!useJWT) {
+          setCookie(event, 'user-data', JSON.stringify({
+            ...user,
+            lastValidated: new Date().toISOString()
+          }), {
+            httpOnly: false, // Allow client access for user state
+            secure: process.env.NODE_ENV === 'production',
+            sameSite: 'strict',
+            maxAge: 60 * 60 * 24 * 7,
+            path: '/'
+          })
+        }
+        
+        return {
+          success: true,
+          user,
+          tokenType: useJWT ? 'jwt' : 'session'
+        }
       }
-    })
-    
+    }
   } catch (error: any) {
-    testResults.tests.push({
-      test: 'Manual Credential Test',
-      status: 'failed',
-      error: {
-        message: error.message,
-        status: error.status || error.statusCode,
-        note: 'Even hardcoded credentials fail'
+    console.error('Login error:', error)
+    
+    // Handle JWT authentication errors
+    if (error.status === 403 || error.status === 401) {
+      return {
+        success: false,
+        message: 'Invalid username or password'
       }
-    })
+    }
+    
+    // Handle JWT endpoint not found (plugin not installed)
+    if (error.status === 404) {
+      return {
+        success: false,
+        message: 'Authentication service not available. Please contact administrator.'
+      }
+    }
+    
+    if (error.code === 'ECONNREFUSED' || error.code === 'ENOTFOUND') {
+      return {
+        success: false,
+        message: 'Unable to connect to authentication server. Please try again later.'
+      }
+    }
+    
+    // Handle other JWT errors
+    if (error.data && error.data.message) {
+      return {
+        success: false,
+        message: error.data.message
+      }
+    }
+    
+    return {
+      success: false,
+      message: 'Login failed. Please try again.'
+    }
   }
   
-  // Test 5: Check WordPress user capabilities
-  try {
-    const response = await $fetch(`${wpEndpoint}/wp/v2/users`, {
-      query: {
-        search: 'mlvalentonis',
-        per_page: 1
-      },
-      timeout: 8000
-    })
-    
-    testResults.tests.push({
-      test: 'User Lookup (Public)',
-      status: 'success',
-      data: {
-        found: response.length > 0,
-        user: response[0] ? {
-          id: response[0].id,
-          username: response[0].username,
-          name: response[0].name,
-          roles: response[0].roles
-        } : null
-      }
-    })
-    
-  } catch (error: any) {
-    testResults.tests.push({
-      test: 'User Lookup (Public)',
-      status: 'failed',
-      error: {
-        message: error.message,
-        status: error.status || error.statusCode
-      }
-    })
+  return {
+    success: false,
+    message: 'Authentication failed'
   }
-  
-  return testResults
 })


### PR DESCRIPTION
## 🎯 Overview
Implements JWT-based authentication to enable users to login to the Nuxt frontend using their regular WordPress credentials instead of requiring Application Passwords.

## 🚀 What's Changed
- **Authentication Flow**: Replaced Application Password authentication with WordPress JWT tokens
- **User Experience**: Users can now login with their standard WordPress username/password
- **Security**: Maintains secure token-based session management
- **Compatibility**: Preserves existing session handling and cookie management

## 🔧 Technical Implementation
### Backend Changes
- Updated `server/api/auth/login.post.ts` to use JWT authentication flow
- Added support for `/jwt-auth/v1/token` endpoint integration
- Enhanced error handling for JWT-specific scenarios
- Maintained backward compatibility with existing session management

### Authentication Flow
1. User submits WordPress credentials
2. System requests JWT token from WordPress
3. JWT token used to fetch user profile data
4. Session token created for frontend state management
5. Secure HTTP-only cookies set for authentication persistence

## 🛡️ Security Considerations
- JWT tokens are validated server-side only
- Session cookies remain HTTP-only and secure
- CORS properly configured for WordPress JWT endpoint
- Error messages don't expose sensitive authentication details

## 📋 Prerequisites
- [x] JWT Authentication for WP REST API plugin installed
- [x] JWT_AUTH_SECRET_KEY configured in WordPress
- [x] CORS enabled for JWT authentication
- [x] WordPress .htaccess updated for GraphQL routing

## 🧪 Testing
- [x] Login with valid WordPress credentials works
- [x] Invalid credentials properly rejected
- [x] Session management maintains user state
- [x] JWT token generation and validation functional
- [x] Error handling covers edge cases

## 🔗 Related Issues
Resolves the authentication issue where users couldn't login with their WordPress passwords, requiring them to use Application Passwords instead.

<img width="1420" height="715" alt="Screenshot 2025-09-17 at 10 34 01 AM" src="https://github.com/user-attachments/assets/4e86b906-c1ea-4f4b-8c61-a112d30c7327" />
<img width="1122" height="647" alt="Screenshot 2025-09-17 at 10 33 54 AM" src="https://github.com/user-attachments/assets/9254d72c-313b-4d07-a8ef-53b937ac003d" />

