### PR TITLE
Migrate deploy to self-hosted runner; add SSH diagnostics

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -7,7 +7,7 @@ This directory contains modular scripts used in the GitHub Actions deployment wo
 ### Core Scripts
 
 - **setup-ssh.sh.obsolete**: [OBSOLETE] Former SSH setup script (kept for reference)
-- **simple-ssh-setup.sh**: Simplified SSH setup that works with standard GitHub Actions secrets
+- **simple-ssh-setup.sh**: SSH setup for optional diagnostics (not used in production deploy)
 - **build-image.sh**: Builds the Docker image for the Nuxt.js application
 - **test-container.sh**: Tests the built Docker container to ensure it works correctly
 - **prepare-server.sh**: Prepares the server for deployment (backup, cleanup, etc.)
@@ -37,19 +37,17 @@ In the GitHub Actions workflow, scripts are called directly:
     # Additional environment variables...
 ```
 
-### On Remote Servers
+### On the VPS (self-hosted runner)
 
-For scripts that need to run on remote servers, the pattern is:
+Deploy scripts run directly on the VPS via the self-hosted runner:
 
 ```yaml
-- name: 🚚 Patchy prepares the server
-  run: |
-    ssh username@server "
-      export VAR1=value1
-      export VAR2=value2
-      
-      $(cat .github/scripts/prepare-server.sh)
-    "
+- name: Prepare server
+  run: bash .github/scripts/prepare-server.sh
+  env:
+    CONTAINER_NAME: ${{ env.CONTAINER_NAME }}
+    DEPLOY_PATH: ${{ env.DEPLOY_PATH }}
+    APP_DIR: ${{ env.APP_DIR }}
 ```
 
 ### Locally
@@ -79,11 +77,12 @@ Each script requires specific environment variables. Here's a summary:
 - `SERVER_USER`: SSH username (no longer used)
 - `SSH_HOST_KEY`: (Optional) Host key for verification
 
-### simple-ssh-setup.sh
+### simple-ssh-setup.sh (diagnostics only)
 - `SSH_PRIVATE_KEY`: The SSH private key
-- `VPS_SERVER`: Hostname or IP of the server (matches GitHub secret name)
-- `VPS_USERNAME`: SSH username (matches GitHub secret name)
+- `VPS_SERVER`: Hostname or IP of the server
+- `VPS_USERNAME`: SSH username
 - `SSH_HOST_KEY`: (Optional) Host key for verification
+- `VPS_PORT`: (Optional) SSH port, default 22
 
 ### build-image.sh
 - `IMAGE_NAME`: Name of the Docker image

--- a/.github/scripts/simple-ssh-setup.sh
+++ b/.github/scripts/simple-ssh-setup.sh
@@ -1,78 +1,90 @@
 #!/bin/bash
 #
-# SSH Setup Script for GitHub Actions
-# This script sets up SSH keys for secure server connections.
+# SSH Setup Script for GitHub Actions (diagnostics only — production deploy uses self-hosted runner)
 #
 
-set -e # Exit on any error
+set -e
 
-# Print colorful messages
-print_info() {
-  echo -e "\033[36m🔑 [SSH SETUP] $1\033[0m"
-}
+DEPLOY_SSH_HOST="${DEPLOY_SSH_HOST:-stellarpossible-deploy}"
+VPS_PORT="${VPS_PORT:-22}"
+SSH_CONNECT_TIMEOUT="${SSH_CONNECT_TIMEOUT:-30}"
+SSH_MAX_ATTEMPTS="${SSH_MAX_ATTEMPTS:-5}"
+SSH_RETRY_DELAYS=(5 10 15 20 25)
 
-print_success() {
-  echo -e "\033[32m✅ [SSH SETUP] $1\033[0m"
-}
+print_info() { echo -e "\033[36m🔑 [SSH SETUP] $1\033[0m"; }
+print_success() { echo -e "\033[32m✅ [SSH SETUP] $1\033[0m"; }
+print_error() { echo -e "\033[31m❌ [SSH SETUP] $1\033[0m"; exit 1; }
 
-print_warning() {
-  echo -e "\033[33m⚠️ [SSH SETUP] $1\033[0m"
-}
+[ -n "$SSH_PRIVATE_KEY" ] || print_error "SSH_PRIVATE_KEY is not set!"
+[ -n "$VPS_SERVER" ] || print_error "VPS_SERVER is not set!"
+[ -n "$VPS_USERNAME" ] || print_error "VPS_USERNAME is not set!"
 
-print_error() {
-  echo -e "\033[31m❌ [SSH SETUP] $1\033[0m"
-  exit 1
-}
+VPS_SERVER="${VPS_SERVER#https://}"
+VPS_SERVER="${VPS_SERVER#http://}"
+VPS_SERVER="${VPS_SERVER%%/*}"
+VPS_SERVER="$(printf '%s' "$VPS_SERVER" | tr -d '[:space:]')"
+VPS_USERNAME="$(printf '%s' "$VPS_USERNAME" | tr -d '[:space:]')"
+VPS_PORT="$(printf '%s' "$VPS_PORT" | tr -d '[:space:]')"
 
-print_info "Setting up SSH keys for GitHub Actions..."
-
-# Check for required environment variables
-if [ -z "$SSH_PRIVATE_KEY" ]; then
-  print_error "SSH_PRIVATE_KEY environment variable is not set!"
-fi
-
-if [ -z "$VPS_SERVER" ]; then
-  print_error "VPS_SERVER environment variable is not set!"
-fi
-
-if [ -z "$VPS_USERNAME" ]; then
-  print_error "VPS_USERNAME environment variable is not set!"
-fi
-
-# Create SSH directory if it doesn't exist
 mkdir -p ~/.ssh
 chmod 700 ~/.ssh
 
-# Write SSH private key (preserve newlines; strip CR from Windows paste; neutral filename)
 DEPLOY_KEY="$HOME/.ssh/id_deploy"
-print_info "Writing SSH private key to file..."
-printf '%s\n' "$SSH_PRIVATE_KEY" | tr -d '\r' > "$DEPLOY_KEY"
+KEY_RAW="$(printf '%s' "$SSH_PRIVATE_KEY" | tr -d '\r')"
+if printf '%s' "$KEY_RAW" | grep -q '\\n'; then
+  printf '%s' "$KEY_RAW" | sed 's/\\n/\n/g' > "$DEPLOY_KEY"
+else
+  printf '%s\n' "$KEY_RAW" > "$DEPLOY_KEY"
+fi
 chmod 600 "$DEPLOY_KEY"
 
-# Prepare known_hosts before SSH config so pinned host keys take effect
+if ! grep -q 'BEGIN .*PRIVATE KEY' "$DEPLOY_KEY"; then
+  print_error "SSH_PRIVATE_KEY does not look like a PEM private key (missing BEGIN … PRIVATE KEY)."
+fi
+
+if ! ssh-keygen -y -f "$DEPLOY_KEY" > "$HOME/.ssh/id_deploy.pub" 2>/dev/null; then
+  print_error "SSH_PRIVATE_KEY is invalid or corrupted. Re-save the secret with: gh secret set SSH_PRIVATE_KEY < ~/.ssh/your_deploy_key"
+fi
+chmod 644 "$HOME/.ssh/id_deploy.pub"
+
 touch ~/.ssh/known_hosts
 chmod 644 ~/.ssh/known_hosts
 if [ -n "$SSH_HOST_KEY" ]; then
-  print_info "Adding provided SSH host key to known_hosts..."
   echo "$VPS_SERVER $SSH_HOST_KEY" >> ~/.ssh/known_hosts
-fi
-
-if [ -n "$SSH_HOST_KEY" ]; then
   HOST_KEY_POLICY=yes
 else
   HOST_KEY_POLICY=accept-new
 fi
 
-# Create SSH config — IdentitiesOnly avoids agent/other keys masking deploy key failures
-print_info "Creating SSH config..."
+SSH_COMMON_OPTS="ConnectTimeout=${SSH_CONNECT_TIMEOUT} ConnectionAttempts=3 ServerAliveInterval=15 ServerAliveCountMax=3 BatchMode=yes"
+
 cat > ~/.ssh/config << EOF
-Host ${VPS_SERVER}
+Host ${DEPLOY_SSH_HOST}
   HostName ${VPS_SERVER}
+  Port ${VPS_PORT}
   User ${VPS_USERNAME}
   IdentityFile ${DEPLOY_KEY}
   IdentitiesOnly yes
   StrictHostKeyChecking ${HOST_KEY_POLICY}
   UserKnownHostsFile ~/.ssh/known_hosts
+  ConnectTimeout ${SSH_CONNECT_TIMEOUT}
+  ConnectionAttempts 3
+  ServerAliveInterval 15
+  ServerAliveCountMax 3
+  LogLevel ERROR
+
+Host ${VPS_SERVER}
+  HostName ${VPS_SERVER}
+  Port ${VPS_PORT}
+  User ${VPS_USERNAME}
+  IdentityFile ${DEPLOY_KEY}
+  IdentitiesOnly yes
+  StrictHostKeyChecking ${HOST_KEY_POLICY}
+  UserKnownHostsFile ~/.ssh/known_hosts
+  ConnectTimeout ${SSH_CONNECT_TIMEOUT}
+  ConnectionAttempts 3
+  ServerAliveInterval 15
+  ServerAliveCountMax 3
   LogLevel ERROR
 
 Host *
@@ -82,20 +94,85 @@ Host *
 EOF
 chmod 644 ~/.ssh/config
 
-# Print SSH key information (sanity check that file parses)
-print_info "SSH key fingerprint:"
-ssh-keygen -lf "$DEPLOY_KEY" || print_warning "Could not get key fingerprint"
+print_info "Private key:"
+ssh-keygen -lf "$DEPLOY_KEY" || print_info "Could not read key fingerprint"
+print_info "Public key (must appear in ~${VPS_USERNAME}/.ssh/authorized_keys on the VPS):"
+cat "$HOME/.ssh/id_deploy.pub"
+print_info "Target: ${VPS_USERNAME}@${VPS_SERVER}:${VPS_PORT} (ssh alias: ${DEPLOY_SSH_HOST})"
 
-# Test SSH connection (explicit host block picks IdentityFile + IdentitiesOnly from config)
-print_info "Testing SSH connection to $VPS_USERNAME@$VPS_SERVER..."
-SSH_OPTS=(-o ConnectTimeout=15 -o BatchMode=yes)
+if [ -n "${GITHUB_ENV:-}" ]; then
+  echo "DEPLOY_SSH_HOST=${DEPLOY_SSH_HOST}" >> "$GITHUB_ENV"
+  echo "GIT_SSH_COMMAND=ssh -o ${SSH_COMMON_OPTS// / -o } -i ${DEPLOY_KEY} -o IdentitiesOnly=yes" >> "$GITHUB_ENV"
+fi
+
+SSH_OPTS=(-o "ConnectTimeout=${SSH_CONNECT_TIMEOUT}" -o ConnectionAttempts=3 -o ServerAliveInterval=15 -o ServerAliveCountMax=3 -o BatchMode=yes)
 if [ "${SSH_DEBUG:-}" = "1" ]; then
   SSH_OPTS+=(-vvv)
 fi
-if ssh "${SSH_OPTS[@]}" "$VPS_SERVER" "echo '🔑 SSH connection successful!'"; then
-  print_success "SSH connection established successfully!"
-else
-  print_error "Failed to establish SSH connection. Please check your SSH key and server details."
+
+LAST_SSH_OUTPUT=""
+attempt_ssh() {
+  local err_file
+  err_file="$(mktemp)"
+  if ssh "${SSH_OPTS[@]}" "$DEPLOY_SSH_HOST" "echo 'SSH connection successful'" 2>"$err_file"; then
+    rm -f "$err_file"
+    return 0
+  fi
+  LAST_SSH_OUTPUT="$(cat "$err_file")"
+  rm -f "$err_file"
+  return 1
+}
+
+print_info "Connecting (up to ${SSH_MAX_ATTEMPTS} attempts, ${SSH_CONNECT_TIMEOUT}s timeout each)..."
+connected=0
+for attempt in $(seq 1 "$SSH_MAX_ATTEMPTS"); do
+  if attempt_ssh; then
+    print_success "SSH connection established (attempt ${attempt}/${SSH_MAX_ATTEMPTS})!"
+    connected=1
+    break
+  fi
+  echo "$LAST_SSH_OUTPUT" | tail -5
+  if [ "$attempt" -lt "$SSH_MAX_ATTEMPTS" ]; then
+    delay="${SSH_RETRY_DELAYS[$((attempt - 1))]:-15}"
+    print_info "Attempt ${attempt}/${SSH_MAX_ATTEMPTS} failed — retrying in ${delay}s..."
+    sleep "$delay"
+  fi
+done
+
+if [ "$connected" -ne 1 ]; then
+  echo ""
+  if echo "$LAST_SSH_OUTPUT" | grep -qiE 'timed out|timeout|no route|network is unreachable|connection refused'; then
+    print_error "SSH connection timed out or was unreachable (${VPS_USERNAME}@${VPS_SERVER}:${VPS_PORT}).
+
+This is a network/firewall issue, not SSH keys. Check:
+  - VPS_SERVER is the VPS origin IP, NOT stellarpossible.com (Cloudflare does not proxy SSH)
+  - Hostinger / ufw allows inbound TCP ${VPS_PORT} from the public internet
+  - fail2ban has not banned GitHub Actions runner IPs: sudo fail2ban-client status sshd
+  - Production deploy no longer requires SSH — use the self-hosted runner (see docs/self-hosted-runner-setup.md)
+
+Last ssh output:
+${LAST_SSH_OUTPUT}"
+  elif echo "$LAST_SSH_OUTPUT" | grep -qiE 'permission denied|publickey'; then
+    print_error "SSH authentication failed for ${VPS_USERNAME}@${VPS_SERVER}.
+
+On the VPS, as a sudo user, run:
+  mkdir -p ~${VPS_USERNAME}/.ssh && chmod 700 ~${VPS_USERNAME}/.ssh
+  echo '<paste the public key line printed above>' >> ~${VPS_USERNAME}/.ssh/authorized_keys
+  chmod 600 ~${VPS_USERNAME}/.ssh/authorized_keys
+  chown -R ${VPS_USERNAME}:${VPS_USERNAME} ~${VPS_USERNAME}/.ssh
+
+Also verify GitHub secrets VPS_USERNAME, VPS_SERVER, and SSH_PRIVATE_KEY.
+
+Last ssh output:
+${LAST_SSH_OUTPUT}"
+  else
+    print_error "Failed to establish SSH connection after ${SSH_MAX_ATTEMPTS} attempts.
+
+Verify VPS_SERVER (origin IP), VPS_USERNAME, VPS_PORT (${VPS_PORT}), and firewall rules.
+
+Last ssh output:
+${LAST_SSH_OUTPUT}"
+  fi
 fi
 
 print_success "SSH setup completed!"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,171 +2,130 @@
 
 This directory contains GitHub Actions workflows for automating deployment and other tasks.
 
-## 🚀 Deployment Workflow
+## Workflows
 
-The `release.yaml` workflow automates the deployment of the StellarPossible Nuxt.js application to a production or staging server.
+| Workflow | File | Triggers |
+|----------|------|----------|
+| Production deploy | `release.yaml` | Push to `main`, GitHub release, manual dispatch |
+| SSH diagnose | `ssh-diagnose.yml` | Manual only — test SSH from GitHub-hosted runner (optional) |
 
-## 📁 Project Structure
+## Production deploy flow
 
-The deployment system uses a modular approach with separate scripts for different parts of the workflow:
+Production deploy uses a **self-hosted runner** on the VPS (labels: `self-hosted`, `linux`, `stellarpossible`). Install once: [docs/self-hosted-runner-setup.md](../../docs/self-hosted-runner-setup.md).
+
+| Job | Runner | Steps |
+|-----|--------|--------|
+| `quality` | `ubuntu-latest` | Typecheck, lint |
+| `deploy` | `self-hosted` on VPS | Build Docker image, smoke test, prepare server, deploy, health checks |
+
+The deploy job runs **on the VPS** — no `scp` or `ssh` from GitHub cloud runners (Hostinger often blocks inbound SSH from Actions).
+
+If the VPS runner is missing or offline, the `deploy` job stays on **Waiting for a runner** until an online runner with label `stellarpossible` is available. Confirm **Settings → Actions → Runners** shows **Idle** before expecting deploy to start.
+
+Overlapping deploys are **queued** (`concurrency: stellarpossible-production-deploy`).
+
+## Project structure
 
 ```
 .github/
 ├── workflows/
 │   ├── release.yaml         # Main workflow file
-│   └── README.md            # Documentation
+│   ├── ssh-diagnose.yml     # Optional SSH connectivity test
+│   └── README.md
 └── scripts/
-    ├── setup-ssh.sh         # SSH setup script (original)
-    ├── simple-ssh-setup.sh  # Simplified SSH setup script
-    ├── build-image.sh       # Docker build script
-    ├── test-container.sh    # Container testing script
-    ├── prepare-server.sh    # Server preparation script
-    ├── deploy-app.sh        # Application deployment script
-    ├── health-check.sh      # Health check script
+    ├── simple-ssh-setup.sh  # SSH setup (diagnostics only)
+    ├── build-image.sh
+    ├── test-container.sh
+    ├── prepare-server.sh
+    ├── deploy-app.sh
+    ├── health-check.sh
     └── utils/
-        ├── slack-notify.sh  # Slack notification utilities
-        └── docker-utils.sh  # Docker-related utilities
+        └── slack-notify.sh
+scripts/
+└── install-actions-runner.sh  # One-time VPS runner install
 ```
 
-This modular structure offers several benefits:
-- Each script has a single responsibility, making the code more maintainable
-- Scripts can be tested individually, both locally and in CI/CD
-- Common functionality is shared across scripts
-- Better error handling and debugging capabilities
-- Scripts can be reused in other workflows or development processes
+## What "Patchy" does
 
-## 🤖 What "Patchy" Does
+1. **Quality gate** (GitHub cloud): checkout, `npm ci`, typecheck, lint
+2. **Deploy** (VPS runner): Slack notification, Docker build, container test
+3. Stage image tarball to `/var/www/stellarpossible.com/nuxt-app`
+4. Prepare server, deploy application, health checks
+5. External URL test and diagnostics
+6. Slack success or failure notification
 
-The workflow, named "Patchy's Docker Deployment Adventure," performs the following steps:
+## Required GitHub secrets
 
-1. **Code Checkout**: Retrieves the latest code from the repository
-2. **Slack Notification**: Sends a deployment start notification to Slack
-3. **Codebase Inspection**: Verifies that all required files exist
-4. **Docker Build**: Builds a Docker image for the Nuxt.js application
-5. **Container Testing**: Tests the container locally to ensure it works
-6. **Image Packaging**: Saves the Docker image as a tar file
-7. **Server Preparation**: Connects to the server and prepares it for deployment
-8. **Image Upload**: Uploads the Docker image to the server
-9. **Application Deployment**: Deploys the application on the server
-10. **Health Checks**: Performs health checks to verify the deployment
-11. **External Testing**: Tests the application from outside the server
-12. **Diagnostics**: Runs final diagnostics to ensure everything is working
-13. **Slack Notification**: Sends a success or failure notification to Slack
+Configure under **Settings → Secrets and variables → Actions** (or the `production` / `staging` environment).
 
-### 🔑 Required Secrets
+| Secret | Description |
+|--------|-------------|
+| `WP_APP_PASSWORD` | WordPress application password |
+| `USE_JWT` | Whether to use JWT authentication |
+| `JWT_SECRET` | JWT secret for authentication |
+| `ADMIN_EMAIL` | Admin email address |
+| `STRIPE_SECRET_KEY` | Stripe secret key |
+| `STRIPE_PRICE_MONTHLY` | Stripe monthly price ID |
+| `STRIPE_PRICE_ANNUAL` | Stripe annual price ID |
+| `NUXT_PUBLIC_SITE_URL` | Public site URL |
+| `SLACK_WEBHOOK_URL` | Optional deploy notifications |
 
-The workflow requires the following secrets to be set in your GitHub repository:
+SSH secrets (`VPS_SERVER`, `VPS_USERNAME`, `SSH_PRIVATE_KEY`, `SSH_HOST_KEY`, `VPS_PORT`) are **optional** — only needed for the [ssh-diagnose.yml](ssh-diagnose.yml) workflow.
 
-- `VPS_SERVER`: The hostname or IP address of your server (used in simple-ssh-setup.sh)
-- `VPS_USERNAME`: The SSH username for connecting to the server (used in simple-ssh-setup.sh)
-- `SSH_PRIVATE_KEY`: Your private SSH key (full key content including headers)
-- `SSH_HOST_KEY`: Your server's SSH host key (optional, get it using `ssh-keyscan`)
-- `SLACK_WEBHOOK_URL`: The Slack webhook URL for notifications
-- `WP_APP_PASSWORD`: The WordPress application password
-- `USE_JWT`: Whether to use JWT authentication
-- `JWT_SECRET`: The JWT secret for authentication
-- `ADMIN_EMAIL`: The admin email address
+## VPS one-time bootstrap
 
-The deployment workflow now uses `simple-ssh-setup.sh` which is specifically designed to work with the `VPS_SERVER` and `VPS_USERNAME` environment variables as they are named in your GitHub repository.
+1. Ensure deploy tree exists at `/var/www/stellarpossible.com/nuxt-app` and user has Docker access
+2. Install self-hosted runner: [docs/self-hosted-runner-setup.md](../../docs/self-hosted-runner-setup.md)
+3. Confirm runner is **Idle** with label `stellarpossible`
+4. Run **Patchy's Docker Deployment Adventure** manually or push to `main`
 
-### 🐛 Troubleshooting Common Issues
+## Troubleshooting
 
-#### SSH Connection Problems
+### Deploy stuck "Waiting for a runner"
 
-If you see **`Permission denied (publickey,password)`** or **`ssh: handshake failed`**:
-
-1. **Matching key pair** — The **`SSH_PRIVATE_KEY`** secret must be the **private** half of the key whose **public** line is in **`~/.ssh/authorized_keys`** on the server for **`VPS_USERNAME`** (often `ssh-copy-id user@host` from your laptop).
-
-2. **No passphrase in CI** — Keys used in Actions must **not** use a passphrase (batch login cannot prompt).
-
-3. **Secret formatting** — Paste the **full** key, including headers/footers and **line breaks**, into **`SSH_PRIVATE_KEY`**:
-   ```
-   -----BEGIN OPENSSH PRIVATE KEY-----
-   ...key content...
-   -----END OPENSSH PRIVATE KEY-----
-   ```
-   Or legacy PEM:
-   ```
-   -----BEGIN RSA PRIVATE KEY-----
-   ...
-   -----END RSA PRIVATE KEY-----
-   ```
-
-4. **`SSH_HOST_KEY` (optional)** — Prefer `ssh-keyscan` output without duplicating the hostname if your secret already includes it:
-   ```bash
-   ssh-keyscan -t rsa,ecdsa,ed25519 YOUR_SERVER_HOST_OR_IP
-   ```
-   Put either the whole line as **`SSH_HOST_KEY`** (and rely on script prefix `VPS_SERVER`) **or** only the algorithm + base64 blob—avoid **`hostname hostname`** duplication.
-
-5. **Debug in Actions** — Add repo variable **`SSH_DEBUG`** = **`1`** on the workflow env **or** run locally with the same secrets to see **`ssh -vvv`** output (`simple-ssh-setup.sh` respects **`SSH_DEBUG=1`**).
-
-6. **Server-side** — On the VPS: **`chmod 700 ~/.ssh`**, **`chmod 600 ~/.ssh/authorized_keys`**, **`PermitRootLogin`** / **`PasswordAuthentication`** don’t fix missing pubkey—confirm **`authorized_keys`** has the matching public key.
-
-#### Docker Container Issues
-
-If the container fails to start:
-
-1. Check for port conflicts on the server:
-   ```bash
-   sudo netstat -tlnp | grep :3000
-   ```
-
-2. View Docker logs:
-   ```bash
-   docker logs stellarpossible-app
-   ```
-
-3. Verify Docker permissions:
-   ```bash
-   sudo usermod -aG docker YOUR_USERNAME
-   ```
-
-#### Application Not Responding
-
-If the application deploys but doesn't respond:
-
-1. Check Nuxt.js server logs:
-   ```bash
-   docker logs stellarpossible-app
-   ```
-
-2. Verify environment variables:
-   ```bash
-   docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' stellarpossible-app
-   ```
-
-3. Test network connectivity:
-   ```bash
-   curl -v http://localhost:3000/
-   ```
-
-### 🧪 Testing the Workflow
-
-You can manually trigger the workflow from the GitHub Actions tab by selecting "Run workflow" and choosing your target environment.
-
-### 🔄 Customizing the Workflow
-
-To customize the workflow:
-
-1. Edit the `.github/workflows/release.yaml` file for workflow structure changes
-2. Modify individual scripts in `.github/scripts/` for specific functionality changes
-3. Update utility scripts in `.github/scripts/utils/` for shared functionality
-4. Modify the environment variables at the top of the workflow file
-
-### 🧩 Working with the Modular Scripts
-
-Each script is designed to be self-contained and can be run individually:
+Runner not installed or offline. On the VPS:
 
 ```bash
-# Running scripts locally (for testing)
+cd ~/actions-runner-stellarpossible
+sudo ./svc.sh status
+sudo ./svc.sh start
+```
+
+Re-install if needed: [scripts/install-actions-runner.sh](../../scripts/install-actions-runner.sh)
+
+### SSH (diagnostics only)
+
+Run **SSH connectivity diagnose** manually. If you see connection timeouts from GitHub-hosted runners, that is expected on Hostinger — production deploy does not use SSH.
+
+For SSH secret setup and host keys, see [docs/ssh-authentication-guide.md](../../docs/ssh-authentication-guide.md).
+
+Set `SSH_DEBUG=1` in the workflow env to get `ssh -vvv` output from `simple-ssh-setup.sh`.
+
+### Docker container issues
+
+```bash
+sudo netstat -tlnp | grep :3000
+docker logs stellarpossible-app
+sudo usermod -aG docker stellaruser
+```
+
+### Application not responding
+
+```bash
+docker logs stellarpossible-app
+docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' stellarpossible-app
+curl -v http://localhost:3000/
+```
+
+## Manual deploy
+
+Actions → **Patchy's Docker Deployment Adventure** → **Run workflow** (requires idle self-hosted runner).
+
+## Working with scripts locally
+
+```bash
 .github/scripts/build-image.sh
 .github/scripts/test-container.sh
 ```
-
-To add new functionality:
-
-1. Create a new script in the `.github/scripts/` directory
-2. Make it executable with `chmod +x .github/scripts/your-script.sh`
-3. Add a new step in the workflow file that calls your script
 
 For more advanced customization, refer to the [GitHub Actions documentation](https://docs.github.com/en/actions).

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,21 +16,51 @@ on:
           - production
           - staging
 
+concurrency:
+  group: stellarpossible-production-deploy
+  cancel-in-progress: false
+
 env:
-  # Opt JavaScript actions into Node.js 24 before GitHub makes it default (Node 20 deprecation).
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   DOCKER_IMAGE_NAME: stellarpossible-nuxt
   CONTAINER_NAME: stellarpossible-app
   DEPLOY_PATH: /var/www/stellarpossible.com
-  SERVER_USER: stellaruser
+  APP_DIR: nuxt-app
+  APP_PORT: "3000"
+  EXTERNAL_URL: https://stellarpossible.com/
 
 jobs:
+  quality:
+    name: Quality gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Quality gate (typecheck, lint)
+        run: |
+          npm ci
+          npm run type-check || echo "::warning::type-check failed (non-blocking)"
+          npm run lint || echo "::warning::lint failed (non-blocking)"
+
   deploy:
     name: 🚀 Patchy's Deployment Mission
-    runs-on: ubuntu-latest
+    needs: quality
+    runs-on: [self-hosted, linux, stellarpossible]
     environment: ${{ github.event.inputs.environment || 'production' }}
-    timeout-minutes: 30
-    
+    timeout-minutes: 45
+
     steps:
       - name: 📋 Patchy checks out the code
         uses: actions/checkout@v5
@@ -41,7 +71,6 @@ jobs:
         run: |
           chmod +x .github/scripts/*.sh
           chmod +x .github/scripts/utils/*.sh
-          ls -la .github/scripts/
 
       - name: 🤖 Patchy announces the mission
         run: |
@@ -54,31 +83,27 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
+      - name: Preflight (Docker on VPS)
+        run: |
+          docker info >/dev/null 2>&1 && echo "Docker OK" || sudo docker info
+          echo "Deploy user: $(whoami)"
+          echo "Deploy path: ${{ env.DEPLOY_PATH }}/${{ env.APP_DIR }}"
+
       - name: 🔍 Patchy inspects the codebase
         run: |
           echo "🤖 Patchy says: Let me see what we're working with here..."
-          echo "📁 Repository structure:"
-          ls -la
-          echo ""
-          echo "📦 Package.json check:"
-          if [[ -f "package.json" ]]; then
-            echo "✅ Package.json found - Patchy approves!"
-          else
+          if [[ ! -f "package.json" ]]; then
             echo "❌ No package.json? Patchy is confused!"
             exit 1
           fi
-          echo ""
-          echo "🐳 Docker setup check:"
-          if [[ -f "Dockerfile" ]]; then
-            echo "✅ Dockerfile found - Patchy loves containers!"
-          else
+          if [[ ! -f "Dockerfile" ]]; then
             echo "❌ No Dockerfile? Patchy needs his containers!"
             exit 1
           fi
+          echo "✅ Package.json and Dockerfile found — Patchy approves!"
 
       - name: 🏗️ Patchy builds the Docker image
-        run: |
-          .github/scripts/build-image.sh
+        run: .github/scripts/build-image.sh
         env:
           IMAGE_NAME: ${{ env.DOCKER_IMAGE_NAME }}
           TAG: latest
@@ -86,86 +111,37 @@ jobs:
           SAVE_IMAGE: "true"
 
       - name: 🧪 Patchy tests the container
-        run: |
-          .github/scripts/test-container.sh
+        run: .github/scripts/test-container.sh
         env:
           IMAGE_NAME: ${{ env.DOCKER_IMAGE_NAME }}
           TAG: latest
           TEST_PORT: 3001
           WAIT_TIME: 15
           MAX_RETRIES: 3
-          WP_USER: "admin"
-          WP_APP_PASSWORD: "test-password"
-          WP_GRAPHQL_ENDPOINT: "https://stellarpossible.com/cms/graphql"
-          WP_REST_ENDPOINT: "https://stellarpossible.com/cms/wp-json"
-          WP_API_URL: "https://stellarpossible.com/cms"
+          WP_USER: admin
+          WP_APP_PASSWORD: test-password
+          WP_GRAPHQL_ENDPOINT: https://stellarpossible.com/cms/graphql
+          WP_REST_ENDPOINT: https://stellarpossible.com/cms/wp-json
+          WP_API_URL: https://stellarpossible.com/cms
           USE_JWT: ${{ secrets.USE_JWT }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
 
-      - name: 🔑 Patchy sets up SSH
-        run: |
-          .github/scripts/simple-ssh-setup.sh
-        env:
-          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-          VPS_SERVER: ${{ secrets.VPS_SERVER }}
-          VPS_USERNAME: ${{ secrets.VPS_USERNAME }}
-          SSH_HOST_KEY: ${{ secrets.SSH_HOST_KEY }}
-
-      - name: 🚚 Patchy prepares the server
-        run: |
-          # Copy the prepare-server.sh script to the server directly
-          scp .github/scripts/prepare-server.sh ${{ secrets.VPS_USERNAME }}@${{ secrets.VPS_SERVER }}:/tmp/prepare-server.sh
-          
-          # Create a simple wrapper script
-          cat > docker-wrapper.sh << 'EOL'
-          #!/bin/bash
-          
-          # Check if Docker socket exists and user has access
-          if [ -e /var/run/docker.sock ]; then
-            if [ -w /var/run/docker.sock ]; then
-              echo "✅ User has direct access to Docker socket"
-            elif groups | grep -q docker; then
-              echo "✅ User is in docker group"
-            else
-              echo "⚠️ Docker permission issue detected, trying to continue anyway..."
-            fi
-          fi
-          
-          # Set DOCKER_CMD for use in the script
-          export DOCKER_CMD="docker"
-          
-          # Execute the prepare-server script with environment variables
-          bash /tmp/prepare-server.sh
-          EOL
-          
-          # Make the wrapper executable and send it to the server
-          chmod +x docker-wrapper.sh
-          scp docker-wrapper.sh ${{ secrets.VPS_USERNAME }}@${{ secrets.VPS_SERVER }}:/tmp/
-          
-          # Execute the wrapper on the remote server
-          ssh ${{ secrets.VPS_USERNAME }}@${{ secrets.VPS_SERVER }} "
-            export CONTAINER_NAME=${{ env.CONTAINER_NAME }}
-            export IMAGE_NAME=${{ env.DOCKER_IMAGE_NAME }}
-            export DEPLOY_PATH=${{ env.DEPLOY_PATH }}
-            export APP_DIR=nuxt-app
-            
-            bash /tmp/docker-wrapper.sh
-          "
-          
-          # Clean up
-          rm docker-wrapper.sh
-
-      - name: 📤 Patchy uploads the new image
+      - name: Stage image tarball
         run: |
           TARFILE="${{ env.DOCKER_IMAGE_NAME }}-${{ github.sha }}.tar.gz"
-          echo "🤖 Patchy is uploading the Docker image to the server..."
-          scp -v "$TARFILE" ${{ secrets.VPS_USERNAME }}@${{ secrets.VPS_SERVER }}:${{ env.DEPLOY_PATH }}/nuxt-app/
-          echo "✅ Image upload complete!"
+          mkdir -p "${{ env.DEPLOY_PATH }}/${{ env.APP_DIR }}"
+          if [ ! -f "$TARFILE" ]; then
+            echo "::error::Missing $TARFILE after build"
+            ls -la
+            exit 1
+          fi
+          cp -f "$TARFILE" "${{ env.DEPLOY_PATH }}/${{ env.APP_DIR }}/"
+          ls -lh "${{ env.DEPLOY_PATH }}/${{ env.APP_DIR }}/$TARFILE"
 
       - name: 🔐 Patchy verifies Stripe secrets
         run: |
           if [ -z "$STRIPE_SECRET_KEY" ]; then
-            echo "::error::STRIPE_SECRET_KEY is not set. Add it in Settings → Secrets and variables → Actions (Repository secrets)."
+            echo "::error::STRIPE_SECRET_KEY is not set. Add it in Settings → Secrets and variables → Actions."
             exit 1
           fi
           if [ -z "$STRIPE_PRICE_MONTHLY" ] || [ -z "$STRIPE_PRICE_ANNUAL" ]; then
@@ -177,198 +153,64 @@ jobs:
           STRIPE_PRICE_MONTHLY: ${{ secrets.STRIPE_PRICE_MONTHLY }}
           STRIPE_PRICE_ANNUAL: ${{ secrets.STRIPE_PRICE_ANNUAL }}
 
+      - name: 🚚 Patchy prepares the server
+        run: bash .github/scripts/prepare-server.sh
+        env:
+          CONTAINER_NAME: ${{ env.CONTAINER_NAME }}
+          IMAGE_NAME: ${{ env.DOCKER_IMAGE_NAME }}
+          DEPLOY_PATH: ${{ env.DEPLOY_PATH }}
+          APP_DIR: ${{ env.APP_DIR }}
+
       - name: 🎯 Patchy deploys the application
-        run: |
-          # Copy our utility scripts to the server
-          echo "🤖 Patchy says: Copying utility scripts to the server..."
-          scp .github/scripts/utils/extract-docker-image.sh ${{ secrets.VPS_USERNAME }}@${{ secrets.VPS_SERVER }}:/tmp/ || echo "⚠️ Failed to copy extraction utility (not critical)"
-          
-          # Copy the deploy-app.sh script to the server directly
-          scp .github/scripts/deploy-app.sh ${{ secrets.VPS_USERNAME }}@${{ secrets.VPS_SERVER }}:/tmp/deploy-app.sh
-          
-          # Create a simple wrapper script
-          cat > deploy-wrapper.sh << 'EOL'
-          #!/bin/bash
-          
-          # Check if Docker socket exists and user has access
-          if [ -e /var/run/docker.sock ]; then
-            if [ -w /var/run/docker.sock ]; then
-              echo "✅ User has direct access to Docker socket"
-              export DOCKER_CMD="docker"
-              export DEPLOY_METHOD="docker"
-            elif groups | grep -q docker; then
-              echo "✅ User is in docker group"
-              export DOCKER_CMD="docker" 
-              export DEPLOY_METHOD="docker"
-            else
-              echo "⚠️ Docker permission issue detected, will use manual deployment method"
-              export DEPLOY_METHOD="manual"
-            fi
-          else
-            echo "⚠️ Docker socket not found, will use manual deployment method"
-            export DEPLOY_METHOD="manual"
-          fi
-          
-          echo "Using deployment method: $DEPLOY_METHOD"
-          
-          # Execute the deploy-app script with all environment variables
-          bash /tmp/deploy-app.sh
-          EOL
-          
-          # Make the wrapper executable and send it to the server
-          chmod +x deploy-wrapper.sh
-          scp deploy-wrapper.sh ${{ secrets.VPS_USERNAME }}@${{ secrets.VPS_SERVER }}:/tmp/
-          
-          # Execute the wrapper on the remote server
-          ssh ${{ secrets.VPS_USERNAME }}@${{ secrets.VPS_SERVER }} "
-            export CONTAINER_NAME=${{ env.CONTAINER_NAME }}
-            export IMAGE_NAME=${{ env.DOCKER_IMAGE_NAME }}
-            export TAG=latest
-            export DEPLOY_PATH=${{ env.DEPLOY_PATH }}
-            export APP_DIR=nuxt-app
-            export TAR_FILE=${{ env.DOCKER_IMAGE_NAME }}-${{ github.sha }}.tar.gz
-            
-            # Set environment variables
-            export WP_USER=admin
-            export WP_APP_PASSWORD='${{ secrets.WP_APP_PASSWORD }}'
-            export WP_GRAPHQL_ENDPOINT=https://stellarpossible.com/cms/graphql
-            export WP_REST_ENDPOINT=https://stellarpossible.com/cms/wp-json
-            export WP_API_URL=https://stellarpossible.com/cms
-            export USE_JWT='${{ secrets.USE_JWT }}'
-            export JWT_SECRET='${{ secrets.JWT_SECRET }}'
-            export ADMIN_EMAIL='${{ secrets.ADMIN_EMAIL }}'
-            export STRIPE_SECRET_KEY='${{ secrets.STRIPE_SECRET_KEY }}'
-            export STRIPE_PRICE_MONTHLY='${{ secrets.STRIPE_PRICE_MONTHLY }}'
-            export STRIPE_PRICE_ANNUAL='${{ secrets.STRIPE_PRICE_ANNUAL }}'
-            export NUXT_PUBLIC_SITE_URL='${{ secrets.NUXT_PUBLIC_SITE_URL }}'
-            
-            bash /tmp/deploy-wrapper.sh
-          "
-          
-          # Clean up
-          rm deploy-wrapper.sh
+        run: bash .github/scripts/deploy-app.sh
+        env:
+          CONTAINER_NAME: ${{ env.CONTAINER_NAME }}
+          IMAGE_NAME: ${{ env.DOCKER_IMAGE_NAME }}
+          TAG: latest
+          DEPLOY_PATH: ${{ env.DEPLOY_PATH }}
+          APP_DIR: ${{ env.APP_DIR }}
+          TAR_FILE: ${{ env.DOCKER_IMAGE_NAME }}-${{ github.sha }}.tar.gz
+          WP_USER: admin
+          WP_APP_PASSWORD: ${{ secrets.WP_APP_PASSWORD }}
+          WP_GRAPHQL_ENDPOINT: https://stellarpossible.com/cms/graphql
+          WP_REST_ENDPOINT: https://stellarpossible.com/cms/wp-json
+          WP_API_URL: https://stellarpossible.com/cms
+          USE_JWT: ${{ secrets.USE_JWT }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_PRICE_MONTHLY: ${{ secrets.STRIPE_PRICE_MONTHLY }}
+          STRIPE_PRICE_ANNUAL: ${{ secrets.STRIPE_PRICE_ANNUAL }}
+          NUXT_PUBLIC_SITE_URL: ${{ secrets.NUXT_PUBLIC_SITE_URL }}
 
       - name: 🏥 Patchy performs health checks
-        run: |
-          # Copy the health-check.sh script to the server directly
-          scp .github/scripts/health-check.sh ${{ secrets.VPS_USERNAME }}@${{ secrets.VPS_SERVER }}:/tmp/health-check.sh
-          
-          # Create a simple wrapper script
-          cat > health-wrapper.sh << 'EOL'
-          #!/bin/bash
-          
-          # Check if Docker socket exists and user has access
-          if [ -e /var/run/docker.sock ]; then
-            if [ -w /var/run/docker.sock ]; then
-              echo "✅ User has direct access to Docker socket"
-              export DOCKER_CMD="docker"
-              export DEPLOY_METHOD="docker"
-            elif groups | grep -q docker; then
-              echo "✅ User is in docker group"
-              export DOCKER_CMD="docker" 
-              export DEPLOY_METHOD="docker"
-            else
-              echo "⚠️ Docker permission issue detected, using manual checks"
-              export DEPLOY_METHOD="manual"
-            fi
-          else
-            echo "⚠️ Docker socket not found, using manual checks"
-            export DEPLOY_METHOD="manual"
-          fi
-          
-          echo "Using health check method: $DEPLOY_METHOD"
-          
-          # Execute the health-check script with environment variables
-          bash /tmp/health-check.sh
-          EOL
-          
-          # Make the wrapper executable and send it to the server
-          chmod +x health-wrapper.sh
-          scp health-wrapper.sh ${{ secrets.VPS_USERNAME }}@${{ secrets.VPS_SERVER }}:/tmp/
-          
-          # Execute the wrapper on the remote server
-          ssh ${{ secrets.VPS_USERNAME }}@${{ secrets.VPS_SERVER }} "
-            export CONTAINER_NAME=${{ env.CONTAINER_NAME }}
-            export HOST=localhost
-            export PORT=3000
-            export RETRIES=5
-            export DELAY=10
-            
-            bash /tmp/health-wrapper.sh
-          "
-          
-          # Clean up
-          rm health-wrapper.sh
+        run: bash .github/scripts/health-check.sh
+        env:
+          CONTAINER_NAME: ${{ env.CONTAINER_NAME }}
+          HOST: localhost
+          PORT: ${{ env.APP_PORT }}
+          RETRIES: 5
+          DELAY: 10
 
       - name: 🌐 Patchy tests external access
         run: |
           echo "🤖 Patchy says: Let's see if the world can reach us!"
-          
-          # Test external access with retries
-          for i in {1..3}; do
-            RESPONSE=$(curl -s -o /dev/null -w '%{http_code}' https://stellarpossible.com/ -m 30)
-            
+          for i in 1 2 3; do
+            RESPONSE=$(curl -s -o /dev/null -w '%{http_code}' "${{ env.EXTERNAL_URL }}" -m 30 || echo "000")
             if [[ "$RESPONSE" == "200" ]]; then
               echo "✅ Patchy celebrates: External access is working perfectly!"
-              break
-            elif [[ $i -eq 3 ]]; then
-              echo "⚠️ Patchy notes: External access returned HTTP $RESPONSE"
-              echo "🤖 This might be due to reverse proxy configuration - checking if app is running locally..."
-              # Don't fail the deployment for external access issues
-            else
-              echo "⏳ Patchy tries again... (Attempt $i, HTTP: $RESPONSE)"
-              sleep 15
+              exit 0
             fi
+            echo "⏳ Patchy tries again... (Attempt $i, HTTP: $RESPONSE)"
+            sleep 15
           done
+          echo "::warning::External URL did not return 200 (nginx/DNS may still be propagating)"
 
       - name: 🔍 Patchy runs final diagnostics
-        run: |
-          # Copy the diagnostics.sh script to the server directly
-          scp .github/scripts/diagnostics.sh ${{ secrets.VPS_USERNAME }}@${{ secrets.VPS_SERVER }}:/tmp/diagnostics.sh
-          
-          # Create a simple wrapper script
-          cat > diagnostics-wrapper.sh << 'EOL'
-          #!/bin/bash
-          
-          # Check if Docker socket exists and user has access
-          if [ -e /var/run/docker.sock ]; then
-            if [ -w /var/run/docker.sock ]; then
-              echo "✅ User has direct access to Docker socket"
-              export DOCKER_CMD="docker"
-              export DEPLOY_METHOD="docker"
-            elif groups | grep -q docker; then
-              echo "✅ User is in docker group"
-              export DOCKER_CMD="docker" 
-              export DEPLOY_METHOD="docker"
-            else
-              echo "⚠️ Docker permission issue detected, using alternative diagnostics"
-              export DEPLOY_METHOD="manual"
-            fi
-          else
-            echo "⚠️ Docker socket not found, using alternative diagnostics"
-            export DEPLOY_METHOD="manual"
-          fi
-          
-          echo "Using diagnostics method: $DEPLOY_METHOD"
-          
-          # Execute the diagnostics script with environment variables
-          bash /tmp/diagnostics.sh
-          EOL
-          
-          # Make the wrapper executable and send it to the server
-          chmod +x diagnostics-wrapper.sh
-          scp diagnostics-wrapper.sh ${{ secrets.VPS_USERNAME }}@${{ secrets.VPS_SERVER }}:/tmp/
-          
-          # Execute the wrapper on the remote server
-          ssh ${{ secrets.VPS_USERNAME }}@${{ secrets.VPS_SERVER }} "
-            export CONTAINER_NAME=${{ env.CONTAINER_NAME }}
-            export PORT=3000
-            
-            bash /tmp/diagnostics-wrapper.sh
-          "
-          
-          # Clean up
-          rm diagnostics-wrapper.sh
+        run: bash .github/scripts/diagnostics.sh
+        env:
+          CONTAINER_NAME: ${{ env.CONTAINER_NAME }}
+          PORT: ${{ env.APP_PORT }}
 
       - name: 🎉 Patchy celebrates success
         if: success()

--- a/.github/workflows/ssh-diagnose.yml
+++ b/.github/workflows/ssh-diagnose.yml
@@ -1,0 +1,49 @@
+name: SSH connectivity diagnose
+
+on:
+  workflow_dispatch:
+
+jobs:
+  diagnose:
+    name: Test SSH from GitHub-hosted runner
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Make scripts executable
+        run: chmod +x .github/scripts/simple-ssh-setup.sh
+
+      - name: Runner egress IP
+        run: |
+          echo "Runner public IP (whitelist test in Hostinger):"
+          curl -s https://api.ipify.org || true
+          echo ""
+
+      - name: TCP probe port 22
+        env:
+          VPS_SERVER: ${{ secrets.VPS_SERVER }}
+          VPS_PORT: ${{ secrets.VPS_PORT }}
+        run: |
+          HOST="${VPS_SERVER#https://}"
+          HOST="${HOST#http://}"
+          HOST="${HOST%%/*}"
+          PORT="${VPS_PORT:-22}"
+          echo "Probing ${HOST}:${PORT} ..."
+          if command -v nc >/dev/null 2>&1; then
+            nc -zv -w 10 "$HOST" "$PORT" || true
+          else
+            timeout 10 bash -c "echo >/dev/tcp/${HOST}/${PORT}" 2>/dev/null && echo "TCP open" || echo "TCP failed"
+          fi
+
+      - name: Setup SSH (optional full test)
+        run: .github/scripts/simple-ssh-setup.sh
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          VPS_SERVER: ${{ secrets.VPS_SERVER }}
+          VPS_USERNAME: ${{ secrets.VPS_USERNAME }}
+          VPS_PORT: ${{ secrets.VPS_PORT }}
+          SSH_HOST_KEY: ${{ secrets.SSH_HOST_KEY }}

--- a/docs/self-hosted-runner-setup.md
+++ b/docs/self-hosted-runner-setup.md
@@ -1,0 +1,117 @@
+# Self-hosted GitHub Actions runner (StellarPossible VPS)
+
+Production deploy uses a **self-hosted runner** on the VPS so GitHub never needs inbound SSH from `ubuntu-latest` runners (Hostinger often blocks those IPs).
+
+The runner pulls jobs over **outbound HTTPS** to GitHub. The `quality` job runs on GitHub-hosted runners; the `deploy` job runs on your server.
+
+## Requirements
+
+- VPS with Docker (same host as the StellarPossible site; often shared with RollCall)
+- Linux user with Docker access (e.g. `stellaruser`)
+- Deploy tree at `/var/www/stellarpossible.com/nuxt-app`
+
+## Coexistence with RollCall
+
+RollCall uses a separate runner in `~/actions-runner` with label `rollcall`. StellarPossible uses:
+
+| Setting | Value |
+|---------|--------|
+| Directory | `~/actions-runner-stellarpossible` |
+| Label | `stellarpossible` |
+| Runner name | `stellarpossible-vps` |
+
+Both runners can run on the same VPS without conflict.
+
+## Get the registration token (GitHub UI)
+
+GitHub does **not** show a separate “Copy token” button. On **Settings → Actions → Runners → New self-hosted runner → Linux**, use the **Configure** block:
+
+```bash
+./config.sh --url https://github.com/StellarPossible/stellarpossible-nuxt --token YOUR_TOKEN_HERE
+```
+
+Copy **only** the string after `--token` (no quotes). It expires in about one hour.
+
+Do **not** stop after GitHub’s `./run.sh` step alone — that omits the custom label **`stellarpossible`** and does not install a systemd service. Use the install script below.
+
+## Install on the VPS (recommended)
+
+1. **New self-hosted runner → Linux** — copy the `--token` value from **Configure** (see above)
+2. On the VPS as `stellaruser`:
+
+```bash
+git clone https://github.com/StellarPossible/stellarpossible-nuxt.git
+cd stellarpossible-nuxt
+export REGISTRATION_TOKEN='paste-value-after--token'
+chmod +x scripts/install-actions-runner.sh
+./scripts/install-actions-runner.sh
+```
+
+The script downloads the runner, registers with labels `self-hosted,linux,stellarpossible`, and installs a systemd service.
+
+## Manual install
+
+Run on the VPS as the deploy user:
+
+```bash
+mkdir -p ~/actions-runner-stellarpossible && cd ~/actions-runner-stellarpossible
+
+curl -o actions-runner-linux-x64.tar.gz -L \
+  https://github.com/actions/runner/releases/download/v2.334.0/actions-runner-linux-x64-2.334.0.tar.gz
+tar xzf actions-runner-linux-x64.tar.gz
+```
+
+Register:
+
+```bash
+cd ~/actions-runner-stellarpossible
+./config.sh --url https://github.com/StellarPossible/stellarpossible-nuxt --token YOUR_TOKEN \
+  --name stellarpossible-vps \
+  --labels self-hosted,linux,stellarpossible \
+  --unattended
+```
+
+Labels must include **`stellarpossible`** — the deploy workflow uses `runs-on: [self-hosted, linux, stellarpossible]`.
+
+Run as a service:
+
+```bash
+cd ~/actions-runner-stellarpossible
+sudo ./svc.sh install stellaruser
+sudo ./svc.sh start
+sudo ./svc.sh status
+```
+
+Replace `stellaruser` with your deploy user.
+
+## Verify
+
+| Check | Expected |
+|-------|----------|
+| **Settings → Actions → Runners** | Runner **Idle** (green) |
+| Labels | `self-hosted`, `Linux`, `stellarpossible` |
+| Workflow | `quality` succeeds on GitHub, `deploy` starts on the VPS runner within seconds |
+
+Re-run **Patchy's Docker Deployment Adventure** or push to `main`.
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| Deploy job stuck “Waiting for a runner” | Runner not installed or offline — run [install-actions-runner.sh](../scripts/install-actions-runner.sh), confirm **Idle** in GitHub, then `cd ~/actions-runner-stellarpossible && sudo ./svc.sh start` |
+| `docker: permission denied` | `sudo usermod -aG docker stellaruser` then re-login |
+| Artifact download fails | Check disk space under `~/actions-runner-stellarpossible/_work` |
+| Wrong labels | Re-configure: `./config.sh --labels self-hosted,linux,stellarpossible --replace` with a new token |
+
+## Optional: SSH secrets
+
+After the self-hosted path is stable, `SSH_PRIVATE_KEY`, `VPS_SERVER`, and `VPS_USERNAME` are not required for production deploy (keep them for [ssh-diagnose.yml](../.github/workflows/ssh-diagnose.yml) if needed).
+
+## Updating the runner
+
+```bash
+cd ~/actions-runner-stellarpossible
+sudo ./svc.sh stop
+# Download newer actions-runner-linux-x64.tar.gz, extract over existing files
+sudo ./svc.sh start
+```

--- a/docs/ssh-authentication-guide.md
+++ b/docs/ssh-authentication-guide.md
@@ -1,35 +1,34 @@
-# SSH Authentication Guide for GitHub Actions
+# SSH Authentication Guide (optional diagnostics)
 
-To fix the SSH authentication issues in the GitHub Actions workflow, you need to set up the following secrets in your GitHub repository:
+Production deploy **does not use SSH**. Deploy runs on a [self-hosted runner](self-hosted-runner-setup.md) on the VPS, which connects outbound to GitHub over HTTPS.
 
-## Required Secrets
+SSH secrets are only needed if you run the optional [ssh-diagnose.yml](../.github/workflows/ssh-diagnose.yml) workflow to test connectivity from GitHub-hosted runners (often blocked by Hostinger).
 
-1. **VPS_SERVER** - The hostname or IP address of your server
-2. **VPS_USERNAME** - The SSH username for connecting to the server
-3. **SSH_PRIVATE_KEY** - Your private SSH key (full key content including headers)
-4. **SSH_HOST_KEY** - The SSH host key fingerprint of your server
+## Optional secrets (diagnostics only)
 
-## How to get the SSH Host Key
+1. **VPS_SERVER** — VPS origin IP address (not `stellarpossible.com`; Cloudflare does not proxy SSH)
+2. **VPS_USERNAME** — SSH username (e.g. `stellaruser`)
+3. **SSH_PRIVATE_KEY** — Private deploy key (full content including headers, no passphrase)
+4. **SSH_HOST_KEY** — Server host key (optional)
+5. **VPS_PORT** — SSH port (default `22`)
 
-To obtain your server's SSH host key, run the following command from your local machine:
+## How to get the SSH host key
+
+From your local machine:
 
 ```bash
-ssh-keyscan -t rsa YOUR_SERVER_IP_OR_HOSTNAME
+ssh-keyscan -t ed25519,rsa,ecdsa YOUR_SERVER_IP_OR_HOSTNAME
 ```
 
-Take the output of this command (excluding the IP/hostname part) and add it as the `SSH_HOST_KEY` secret.
+Use only the algorithm + base64 blob (without the hostname) as `SSH_HOST_KEY` — the setup script prepends `VPS_SERVER`.
 
-## Troubleshooting
+## Troubleshooting SSH diagnostics
 
-If you continue experiencing SSH issues:
+1. Ensure the deploy key has no passphrase
+2. Verify the public key is in `~/.ssh/authorized_keys` on the server for `VPS_USERNAME`
+3. Use the VPS origin IP, not the Cloudflare-proxied domain
+4. Connection timeouts from GitHub Actions are a firewall/network issue — use the self-hosted runner for deploy instead
 
-1. Ensure your SSH key has the correct permissions on your local machine (`chmod 600 ~/.ssh/id_rsa`)
-2. Verify that your SSH public key is added to the `~/.ssh/authorized_keys` file on the server
-3. Check that your server user has permission to run Docker commands
-4. Make sure the paths in the workflow match your actual server configuration
+## Production deploy
 
-## Additional Notes
-
-- The workflow now uses direct SSH commands instead of action plugins for improved control and debugging
-- All escape sequences in quoted command strings are properly handled
-- The SSH key is securely stored as a GitHub secret and set up with the correct permissions during the workflow run
+See [self-hosted-runner-setup.md](self-hosted-runner-setup.md) for installing the VPS runner (label `stellarpossible`).

--- a/scripts/install-actions-runner.sh
+++ b/scripts/install-actions-runner.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# One-time GitHub Actions self-hosted runner install for StellarPossible production deploy.
+# Run ON THE VPS as the deploy user (Docker access).
+#
+#   GitHub → Settings → Actions → Runners → New self-hosted runner → Linux
+#   Under Configure, copy the value after --token from the config.sh line (no separate copy button)
+#   export REGISTRATION_TOKEN='that-token-value'   # expires in ~1 hour
+#   ./scripts/install-actions-runner.sh
+#
+set -euo pipefail
+
+RUNNER_VERSION="${RUNNER_VERSION:-2.334.0}"
+REPO_URL="${REPO_URL:-https://github.com/StellarPossible/stellarpossible-nuxt}"
+RUNNER_NAME="${RUNNER_NAME:-stellarpossible-vps}"
+RUNNER_DIR="${RUNNER_DIR:-$HOME/actions-runner-stellarpossible}"
+RUNNER_USER="${RUNNER_USER:-$(whoami)}"
+RUNNER_LABELS="${RUNNER_LABELS:-self-hosted,linux,stellarpossible}"
+
+print_step() { echo -e "\n\033[36m==> $1\033[0m"; }
+print_ok() { echo -e "\033[32mOK: $1\033[0m"; }
+print_err() { echo -e "\033[31mERROR: $1\033[0m" >&2; exit 1; }
+
+if [ -z "${REGISTRATION_TOKEN:-}" ]; then
+  print_err "Set REGISTRATION_TOKEN to the value after --token in the Configure step (Settings → Actions → Runners → New self-hosted runner → Linux)."
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  print_err "curl is required"
+fi
+
+ARCHIVE="actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
+DOWNLOAD_URL="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${ARCHIVE}"
+
+print_step "Prepare runner directory ($RUNNER_DIR)"
+mkdir -p "$RUNNER_DIR"
+cd "$RUNNER_DIR"
+
+if [ -f ./config.sh ] && [ -f ./run.sh ]; then
+  print_ok "Existing runner files found — re-configuring labels if needed"
+else
+  print_step "Download runner v${RUNNER_VERSION}"
+  curl -fsSL -o "$ARCHIVE" "$DOWNLOAD_URL"
+  tar xzf "$ARCHIVE"
+  rm -f "$ARCHIVE"
+  print_ok "Extracted runner"
+fi
+
+print_step "Register runner ($RUNNER_NAME) → $REPO_URL"
+./config.sh --url "$REPO_URL" --token "$REGISTRATION_TOKEN" \
+  --name "$RUNNER_NAME" \
+  --labels "$RUNNER_LABELS" \
+  --unattended \
+  --replace
+
+print_step "Install systemd service (user: $RUNNER_USER)"
+if [ -f ./svc.sh ]; then
+  sudo ./svc.sh install "$RUNNER_USER" || print_err "svc.sh install failed (run with sudo access)"
+  sudo ./svc.sh start
+  sudo ./svc.sh status || true
+  print_ok "Runner service started"
+else
+  print_err "svc.sh not found in $RUNNER_DIR"
+fi
+
+echo ""
+print_ok "Next: GitHub → Settings → Actions → Runners — status should be Idle with labels: $RUNNER_LABELS"
+print_ok "Then re-run Patchy's Docker Deployment Adventure or push to main"


### PR DESCRIPTION
Switch production deploy to run on a self-hosted VPS runner and add optional SSH diagnostics. Key changes:

- release.yaml: add concurrency, quality job (typecheck/lint), run deploy on [self-hosted, linux, stellarpossible], increased timeouts, stage image tarball on the VPS path, run prepare/deploy/health-check/diagnostics scripts locally on the runner (removed scp/remote wrapper steps), and verify secrets.
- .github/scripts/simple-ssh-setup.sh: rewritten as a diagnostics-focused SSH setup with better validation, retries, informative errors, and environment exports (not used for production deploy).
- .github/scripts/README.md and .github/workflows/README.md: updated docs to reflect self-hosted runner workflow, SSH diagnostics, and new file layout.
- Added .github/workflows/ssh-diagnose.yml: manual workflow to test SSH connectivity from GitHub-hosted runners.
- Added docs/self-hosted-runner-setup.md: instructions for installing and managing the VPS self-hosted runner.
- Updated docs/ssh-authentication-guide.md to mark SSH as optional (diagnostics only) and clarified host key guidance.
- Added scripts/install-actions-runner.sh: one-step installer to register and install the runner as a systemd service on the VPS.

These changes move production deploys off GitHub-hosted runners (avoiding inbound SSH issues with Hostinger), introduce a lightweight CI quality gate, and provide tools/docs to diagnose SSH connectivity when needed.