### PR TITLE
Remove hero and pricing helper copy

### DIFF
--- a/components/home/HomeHero.vue
+++ b/components/home/HomeHero.vue
@@ -14,11 +14,6 @@
           <AppButton to="/services" variant="ghost" size="lg" block class="home-hero__btn home-hero__btn--secondary">Services</AppButton>
           <AppButton v-if="!user" to="/login?tab=register" variant="ghost" size="sm" block class="home-hero__btn home-hero__btn--secondary">Login</AppButton>
         </div>
-        <div class="home-hero__trust">
-          <StatBadge value="99.9%" label="Uptime since 2022" />
-          <StatBadge value="4+" label="Client platforms" />
-          <StatBadge value="2022" label="Serving since" />
-        </div>
       </GlassCard>
     </Reveal>
   </section>
@@ -90,16 +85,6 @@ const { path: primaryCtaPath, label: primaryCtaLabel } = usePrimaryCta()
   flex-wrap: wrap;
   justify-content: center;
   gap: var(--space-3);
-  margin-bottom: var(--space-10);
-}
-
-.home-hero__trust {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: var(--space-4);
-  padding-top: var(--space-6);
-  border-top: 1px solid var(--color-border);
 }
 
 @media (max-width: 768px) {
@@ -116,13 +101,6 @@ const { path: primaryCtaPath, label: primaryCtaLabel } = usePrimaryCta()
     flex-direction: column;
     align-items: stretch;
     gap: var(--space-2);
-    margin-bottom: var(--space-8);
-  }
-
-  .home-hero__trust {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: var(--space-3);
   }
 }
 

--- a/pages/services.vue
+++ b/pages/services.vue
@@ -37,7 +37,6 @@
           <div class="pricing-block">
             <div class="pricing-block__header">
               <span class="services-label">Website &amp; hosting</span>
-              <p class="pricing-block__lead">Transparent build pricing — every site includes managed hosting and migration to the StellarPossible server.</p>
             </div>
 
             <div class="pricing-grid">
@@ -326,13 +325,6 @@ useSeo({
 
 .pricing-block__header {
   margin-bottom: var(--space-5);
-}
-
-.pricing-block__lead {
-  margin: 0;
-  font-size: var(--fs-200);
-  color: var(--color-text-muted);
-  line-height: 1.55;
 }
 
 .pricing-grid {


### PR DESCRIPTION
Simplifies the homepage hero and services pricing sections by removing the trust stats row and the website hosting lead text, along with their unused styles. This tightens the layouts and reduces secondary copy in both sections.